### PR TITLE
[WIP] Set priority of layers to 12

### DIFF
--- a/meta-aos-rcar-gen4-control-domain/conf/layer.conf
+++ b/meta-aos-rcar-gen4-control-domain/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "aos-rcar-gen4-control-domain"
 BBFILE_PATTERN_aos-rcar-gen4-control-domain := "^${LAYERDIR}/"
-BBFILE_PRIORITY_aos-rcar-gen4-control-domain = "7"
+BBFILE_PRIORITY_aos-rcar-gen4-control-domain = "12"
 
 LAYERSERIES_COMPAT_aos-rcar-gen4-control-domain = "dunfell"

--- a/meta-aos-rcar-gen4-dom0/conf/layer.conf
+++ b/meta-aos-rcar-gen4-dom0/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "aos-rcar-gen4-dom0"
 BBFILE_PATTERN_aos-rcar-gen4-dom0 := "^${LAYERDIR}/"
-BBFILE_PRIORITY_aos-rcar-gen4-dom0 = "6"
+BBFILE_PRIORITY_aos-rcar-gen4-dom0 = "12"
 
 LAYERSERIES_COMPAT_aos-rcar-gen4-dom0 = "dunfell"

--- a/meta-aos-rcar-gen4-domd/conf/layer.conf
+++ b/meta-aos-rcar-gen4-domd/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "aos-rcar-gen4-domd"
 BBFILE_PATTERN_aos-rcar-gen4-domd := "^${LAYERDIR}/"
-BBFILE_PRIORITY_aos-rcar-gen4-domd = "6"
+BBFILE_PRIORITY_aos-rcar-gen4-domd = "12"
 
 LAYERSERIES_COMPAT_aos-rcar-gen4-domd = "dunfell"

--- a/meta-aos-rcar-gen4-domu/conf/layer.conf
+++ b/meta-aos-rcar-gen4-domu/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "aos-rcar-gen4-domu"
 BBFILE_PATTERN_aos-rcar-gen4-domu := "^${LAYERDIR}/"
-BBFILE_PRIORITY_aos-rcar-gen4-domu = "6"
+BBFILE_PRIORITY_aos-rcar-gen4-domu = "12"
 
 LAYERSERIES_COMPAT_aos-rcar-gen4-domu = "dunfell"

--- a/meta-aos-rcar-gen4-domx/conf/layer.conf
+++ b/meta-aos-rcar-gen4-domx/conf/layer.conf
@@ -12,6 +12,6 @@ BBFILES_DYNAMIC += " \
 
 BBFILE_COLLECTIONS += "aos-rcar-gen4-domx"
 BBFILE_PATTERN_aos-rcar-gen4-domx := "^${LAYERDIR}/"
-BBFILE_PRIORITY_aos-rcar-gen4-domx = "6"
+BBFILE_PRIORITY_aos-rcar-gen4-domx = "12"
 
 LAYERSERIES_COMPAT_aos-rcar-gen4-domx = "dunfell"

--- a/meta-aos-rcar-gen4-driver-domain/conf/layer.conf
+++ b/meta-aos-rcar-gen4-driver-domain/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "aos-rcar-gen4-driver-domain"
 BBFILE_PATTERN_aos-rcar-gen4-driver-domain := "^${LAYERDIR}/"
-BBFILE_PRIORITY_aos-rcar-gen4-driver-domain = "6"
+BBFILE_PRIORITY_aos-rcar-gen4-driver-domain = "12"
 
 LAYERSERIES_COMPAT_aos-rcar-gen4-driver-domain = "dunfell"


### PR DESCRIPTION
To make sure that specific components can override/redefine settings from more generic levels, we set the following priorities for levels:

```
meta-xt-common     -  8
meta-xt-<platform> - 10
meta-<product>     - 12
```

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>