### PR TITLE
yaml: add meta-xt-domx-gen4

### DIFF
--- a/aos-rcar-gen4.yaml
+++ b/aos-rcar-gen4.yaml
@@ -225,6 +225,7 @@ components:
         - "../meta-xt-common/meta-xt-domx"
         - "../meta-xt-common/meta-xt-driver-domain"
         - "../meta-xt-rcar/meta-xt-gateway/meta-xt-domd-gen4"
+        - "../meta-xt-rcar/meta-xt-gateway/meta-xt-domx-gen4"
         - "../meta-aos-rcar-gen4/meta-aos-rcar-gen4-domx"
         - "../meta-aos-rcar-gen4/meta-aos-rcar-gen4-driver-domain"
         - "../meta-aos-rcar-gen4/meta-aos-rcar-gen4-domd"


### PR DESCRIPTION
After rework of meta-xt-rcar, some recipes are moved to the -domx directory.

---

Have to be merged only after https://github.com/xen-troops/meta-xt-rcar/pull/46