### PR TITLE
[domd] Add udev rule to disable L3 offload

### DIFF
--- a/meta-aos-rcar-gen4-domd/recipes-core/images/aos-image-rcar.bb
+++ b/meta-aos-rcar-gen4-domd/recipes-core/images/aos-image-rcar.bb
@@ -30,7 +30,10 @@ IMAGE_INSTALL += " kernel-module-ixgbe"
 
 IMAGE_INSTALL += " e2fsprogs"
 
-IMAGE_INSTALL += " aos-messageproxy"
+IMAGE_INSTALL += " \
+    aos-messageproxy \
+    aos-udev-rules \
+"
 
 # Set fixed rootfs size
 IMAGE_ROOTFS_SIZE ?= "1048576"

--- a/meta-aos-rcar-gen4-domd/recipes-core/udev/aos-udev-rules.bb
+++ b/meta-aos-rcar-gen4-domd/recipes-core/udev/aos-udev-rules.bb
@@ -1,0 +1,12 @@
+DESCRIPTION = "udev rules for Aos cores"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = " \
+    file://90-disable-offload.rules \
+"
+
+do_install () {
+    install -d ${D}${sysconfdir}/udev/rules.d
+    install -m 0644 ${WORKDIR}/90-disable-offload.rules ${D}${sysconfdir}/udev/rules.d/
+}

--- a/meta-aos-rcar-gen4-domd/recipes-core/udev/aos-udev-rules/90-disable-offload.rules
+++ b/meta-aos-rcar-gen4-domd/recipes-core/udev/aos-udev-rules/90-disable-offload.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="net", DEVPATH=="/devices/platform/soc/e68c0000.ethernet/net/tsn0", RUN+="/bin/bash -c 'echo 0 > /sys/devices/platform/soc/e68c0000.ethernet/l3_offload'"


### PR DESCRIPTION
L3 offload breaks access of host resources. As temporary WA disable it till proper solution will be found.