### PR TITLE
aos-rcar-gen4.yaml: fix custom script path's

### DIFF
--- a/aos-rcar-gen4.yaml
+++ b/aos-rcar-gen4.yaml
@@ -279,7 +279,7 @@ components:
     builder:
       type: custom_script
       work_dir: "layers"
-      script: "yocto/meta-aos/scripts/layer_builder.py"
+      script: "../yocto/meta-aos/scripts/layer_builder.py"
       target_images:
         - "output/layers/nodejs-layer.tar"
         - "output/layers/pylibs-layer.tar"
@@ -289,9 +289,9 @@ components:
         - "%{YOCTOS_WORK_DIR}/%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/%{AOS_BASE_IMAGE}-%{MACHINE}.ext4"
 
       layers:
-        yocto_dir: "%{YOCTOS_WORK_DIR}"
+        yocto_dir: "../%{YOCTOS_WORK_DIR}"
         build_dir: "%{DOMD_BUILD_DIR}"
-        output_dir: "output/layers"
+        output_dir: "../output/layers"
         base_image: "%{AOS_BASE_IMAGE}"
         items:
           nodejs-layer:


### PR DESCRIPTION
After updating the moulin to the latest version, the logic of the 'custom_script' builder was changed, which caused a build failure.

This patch adapts the moulin yaml configuration file to consider the latest moulin logic.