### PR TITLE
[DRAFT]aos-updatemanager: add the configuration to update demo IC

### DIFF
--- a/meta-aos-rcar-gen4-domd/recipes-aos/aos-updatemanager/files/main-node/aos_updatemanager.cfg
+++ b/meta-aos-rcar-gen4-domd/recipes-aos/aos-updatemanager/files/main-node/aos_updatemanager.cfg
@@ -56,6 +56,21 @@
                 "targetFile": "/var/aos/downloads/rh850/OTA_AlcoholApp_Image",
                 "timeout": "1m"
             }
+        },
+	{
+            "ID": "cluster",
+            "Disabled": false,
+            "UpdatePriority": 0,
+            "RebootPriority": 0,
+            "Plugin": "sshmodule",
+            "Params": {
+	        "Host":"cockpit:22",
+		"User":"root",
+		"DestPath":"/tmp/update-mode.tar.bz2",
+		"Commands":[
+		        "cd /tmp/ && tar xf ./update-mode.tar.bz2 && ./update-cluster.sh"
+	  	]
+            }
         }
     ],
     "migration": {

--- a/meta-aos-rcar-gen4-domx/recipes-aos/aos-updatemanager/aos-updatemanager_git.bbappend
+++ b/meta-aos-rcar-gen4-domx/recipes-aos/aos-updatemanager/aos-updatemanager_git.bbappend
@@ -9,6 +9,7 @@ SRC_URI += " \
 AOS_UM_UPDATE_MODULES = " \
     updatemodules/overlayxenstore \
     updatemodules/ubootdualpart \
+    updatemodules/sshmodule \
 "
 
 FILES:${PN} += " \

--- a/misc/multi_node_config.json
+++ b/misc/multi_node_config.json
@@ -44,6 +44,9 @@
         },
         {
             "id": "rcar-multinode-zephyr-1.0-h3ulcb-domd"
+        },
+	{
+            "id": "rcar-multinode-zephyr-1.0-h3ulcb-cluster"
         }
     ]
 }

--- a/misc/single_node_config.json
+++ b/misc/single_node_config.json
@@ -8,6 +8,9 @@
         },
         {
             "id": "rcar-gen4-1.0-spider-rh850"
+        },
+        {
+            "id": "rcar-gen4-1.0-spider-cluster"
         }
     ],
     "formatVersion": 1


### PR DESCRIPTION
Update manager is used to change the mode of the instrument cluster at the demonstration board.
The following components have been added to provide the update: -rcar-multinode-zephyr-1.0-h3ulcb-cluster for multi-node configuration. -rcar-gen4-1.0-spider-cluster for single-node configuration.

All update bundles must have the reference at the component to have the successfull update.
See https://https://github.com/xen-troops/meta-xt-prod-cockpit-rcar/tree/master/scripts/ic-update to generate the update bundle.